### PR TITLE
fix: versioning ignoring gitversion config 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,7 +57,8 @@ jobs:
 
     - name: Calculate Version
       uses: gittools/actions/gitversion/execute@v4.1.0
-
+      with:
+        configFilePath: GitVersion.yml
       id: gitversion
 
     - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,8 @@ jobs:
     - name: Calculate Version
       id: version
       uses: gittools/actions/gitversion/execute@v4.1.0
+      with:
+        configFilePath: GitVersion.yml
 
     - name: Check if release should be created
       id: check
@@ -236,6 +238,8 @@ jobs:
     - name: Calculate Version
       id: version
       uses: gittools/actions/gitversion/execute@v4.1.0
+      with:
+        configFilePath: GitVersion.yml
 
     - name: Cache NuGet packages
       uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release Workflow Permissions**: Fixed workflow_call permissions issue by granting statuses:write to build-test.yml calls
 - **Updated GitHub Actions**: Upgraded all actions to latest versions (checkout@v4, setup-dotnet@v4, cache@v4, gitversion@v4.1.0, gh-release@v2, github-script@v7)
 - **GitVersion 6.4.0 Upgrade**: Updated from 5.12.0 to 6.4.0 for improved performance, .NET 8 compatibility, and latest semantic versioning features
+- **GitVersion Configuration Fix**: Added configFilePath parameter to ensure GitVersion.yml is read by v4.1.0 actions (fixes version mismatch between local and CI)
 - **Artifact Management**: Build artifacts shared between jobs for faster test execution
 - **Visual Status Indicators**: Emoji-enhanced job names for better CI/CD visibility (🏗️ Build, 🧪 Test)
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,5 @@
 mode: ContinuousDelivery
+next-version: 1.1.0
 
 major-version-bump-message: '\+semver:\s?(breaking|major)|(BREAKING CHANGE)'
 minor-version-bump-message: '\+semver:\s?(feature|minor)|^(feat|add|new):'


### PR DESCRIPTION
This pull request addresses a versioning configuration issue in the CI/CD pipelines by ensuring that the `GitVersion.yml` configuration file is explicitly used in all relevant GitHub Actions workflows. This change ensures consistent version calculation between local development and CI, and documents the fix in the changelog. Additionally, the default `next-version` is set in `GitVersion.yml` to streamline future releases.

**CI/CD Workflow Improvements:**

* Explicitly specify the `configFilePath: GitVersion.yml` parameter in the `gittools/actions/gitversion/execute@v4.1.0` step for both `build-test.yml` and `release.yml` workflows to ensure the correct versioning configuration is used in CI. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L60-R61) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R73-R74) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R241-R242)

**Versioning Configuration:**

* Add `next-version: 1.1.0` to `GitVersion.yml` to set the default starting version for future releases.

**Documentation:**

* Update `CHANGELOG.md` to note the addition of the `configFilePath` parameter, which resolves version mismatches between local and CI environments.