### PR TITLE
immutable release fixes 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,23 @@ jobs:
           echo "availability=Available on GitHub Packages and NuGet.org" >> $GITHUB_OUTPUT
         fi
 
+    - name: Prepare Release Assets
+      run: |
+        echo "📦 Preparing release assets..."
+        mkdir -p ./release-assets
+        cp ./packages/*.nupkg ./release-assets/ 2>/dev/null || true
+        
+        # Only copy symbol packages if they exist
+        if ls ./packages/*.snupkg 1> /dev/null 2>&1; then
+          echo "✅ Symbol packages found, including in release"
+          cp ./packages/*.snupkg ./release-assets/
+        else
+          echo "ℹ️  No symbol packages found, skipping"
+        fi
+        
+        echo "📁 Release assets:"
+        ls -la ./release-assets/
+
     - name: Create GitHub Release
       id: create_release
       uses: softprops/action-gh-release@v2
@@ -393,12 +410,12 @@ jobs:
           - **Commit**: ${{ github.sha }}
           - **Branch**: ${{ github.ref_name }}
           - **Workflow**: ${{ github.run_id }}
-        files: |
-          ./packages/*.nupkg
-          ./packages/*.snupkg
+        files: ./release-assets/*
         draft: false
         prerelease: ${{ contains(steps.version.outputs.semVer, '-') }}
         generate_release_notes: false
+        fail_on_unmatched_files: false
+        make_latest: ${{ !contains(steps.version.outputs.semVer, '-') }}
 
     - name: Publish to GitHub Packages
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Updated GitHub Actions**: Upgraded all actions to latest versions (checkout@v4, setup-dotnet@v4, cache@v4, gitversion@v4.1.0, gh-release@v2, github-script@v7)
 - **GitVersion 6.4.0 Upgrade**: Updated from 5.12.0 to 6.4.0 for improved performance, .NET 8 compatibility, and latest semantic versioning features
 - **GitVersion Configuration Fix**: Added configFilePath parameter to ensure GitVersion.yml is read by v4.1.0 actions (fixes version mismatch between local and CI)
+- **Immutable Release Support**: Modified release workflow for atomic release creation compatible with GitHub's immutable release branch protection rules
 - **Artifact Management**: Build artifacts shared between jobs for faster test execution
 - **Visual Status Indicators**: Emoji-enhanced job names for better CI/CD visibility (🏗️ Build, 🧪 Test)
 


### PR DESCRIPTION
This pull request updates the release workflow to better support immutable releases and atomic asset handling, aligning with GitHub's branch protection rules. The main improvements include preparing release assets in a dedicated directory before release, updating the asset upload mechanism, and enhancing workflow robustness and clarity.

Release workflow improvements:

* Added a "Prepare Release Assets" step to collect `.nupkg` and `.snupkg` files into a `release-assets` directory before creating the GitHub release, ensuring atomic and consistent asset uploads.
* Updated the release asset upload to use the `./release-assets/*` glob, simplifying asset management and ensuring only prepared files are uploaded.
* Set `fail_on_unmatched_files: false` to prevent workflow failures if some expected assets are missing, and added `make_latest` to automatically mark non-prerelease versions as the latest.

Documentation updates:

* Added a changelog entry describing "Immutable Release Support" and the atomic release creation for compatibility with GitHub's immutable release branch protection rules.