### PR TITLE
fix: use correct version formats for .NET build properties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,8 +426,8 @@ jobs:
         dotnet build \
           --configuration Release \
           --no-restore \
-          -p:Version=${{ steps.version.outputs.assemblySemVer }} \
-          -p:AssemblyVersion=${{ steps.version.outputs.assemblySemVer }} \
+          -p:Version=${{ steps.version.outputs.semVer }} \
+          -p:AssemblyVersion=${{ steps.version.outputs.assemblySemFileVer }} \
           -p:FileVersion=${{ steps.version.outputs.assemblySemFileVer }} \
           -p:InformationalVersion=${{ steps.version.outputs.informationalVersion }} \
           -p:ContinuousIntegrationBuild=true \


### PR DESCRIPTION
- Fix AssemblyVersion to use assemblySemFileVer (4-part numeric) instead of assemblySemVer
- Fix Version property to use semVer (semantic version) for package versioning
- Ensure AssemblyVersion and FileVersion both use 4-part format (1.3.0.0)
- Allow Version and InformationalVersion to use semantic format (1.3.0-alpha.0)

This resolves the 'does not conform to recommended format' error by ensuring .NET assembly properties receive the correct version format types:
- AssemblyVersion/FileVersion: 1.3.0.0 (4-part numeric)
- Version/InformationalVersion: 1.3.0-alpha.0 (semantic with pre-release)"