### PR TITLE
release pipeline fixes 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,12 +175,16 @@ jobs:
         if git tag --list | grep -q "^v$CURRENT_VERSION$"; then
           echo "⚠️ Version $CURRENT_VERSION already exists as a tag"
           echo "should_release=false" >> $GITHUB_OUTPUT
-        elif [[ "$CURRENT_VERSION" == *"-"* ]] && [[ "$EVENT_NAME" != "workflow_dispatch" ]]; then
-          echo "⚠️ Pre-release version $CURRENT_VERSION - skipping automatic release"
-          echo "should_release=false" >> $GITHUB_OUTPUT
         else
           echo "✅ Should create release for version $CURRENT_VERSION"
           echo "should_release=true" >> $GITHUB_OUTPUT
+          
+          # Determine publishing strategy
+          if [[ "$CURRENT_VERSION" == *"-beta"* ]] || [[ "$CURRENT_VERSION" == *"-rc"* ]] || [[ "$CURRENT_VERSION" != *"-"* ]]; then
+            echo "📦 Will publish to NuGet.org + GitHub Packages (beta/rc/stable)"
+          else
+            echo "📦 Will publish to GitHub Packages only (development/alpha)"
+          fi
         fi
 
     - name: Extract release notes from CHANGELOG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,13 @@ jobs:
         # Set all GitVersion outputs, using override version where applicable
         echo "semVer=$OVERRIDE_VERSION" >> $GITHUB_OUTPUT
         echo "assemblySemVer=$OVERRIDE_VERSION" >> $GITHUB_OUTPUT
-        echo "assemblySemFileVer=$OVERRIDE_VERSION" >> $GITHUB_OUTPUT
+        # Create 4-part version for assemblySemFileVer (major.minor.patch.0)
+        if [[ "$OVERRIDE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          FILE_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.0"
+          echo "assemblySemFileVer=$FILE_VERSION" >> $GITHUB_OUTPUT
+        else
+          echo "assemblySemFileVer=$OVERRIDE_VERSION.0" >> $GITHUB_OUTPUT
+        fi
         echo "informationalVersion=$OVERRIDE_VERSION+$AUTO_BUILD" >> $GITHUB_OUTPUT
         
         # Extract version parts from override version
@@ -378,7 +384,13 @@ jobs:
         # Set all GitVersion outputs, using override version where applicable
         echo "semVer=$OVERRIDE_VERSION" >> $GITHUB_OUTPUT
         echo "assemblySemVer=$OVERRIDE_VERSION" >> $GITHUB_OUTPUT
-        echo "assemblySemFileVer=$OVERRIDE_VERSION" >> $GITHUB_OUTPUT
+        # Create 4-part version for assemblySemFileVer (major.minor.patch.0)
+        if [[ "$OVERRIDE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          FILE_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.0"
+          echo "assemblySemFileVer=$FILE_VERSION" >> $GITHUB_OUTPUT
+        else
+          echo "assemblySemFileVer=$OVERRIDE_VERSION.0" >> $GITHUB_OUTPUT
+        fi
         echo "informationalVersion=$OVERRIDE_VERSION+$AUTO_BUILD" >> $GITHUB_OUTPUT
         
         # Extract version parts from override version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,8 +426,8 @@ jobs:
         dotnet build \
           --configuration Release \
           --no-restore \
-          -p:Version=${{ steps.version.outputs.assemblySemVer }} \
-          -p:AssemblyVersion=${{ steps.version.outputs.assemblySemVer }} \
+          -p:Version=${{ steps.version.outputs.semVer }} \
+          -p:AssemblyVersion=${{ steps.version.outputs.assemblySemFileVer }} \
           -p:FileVersion=${{ steps.version.outputs.assemblySemFileVer }} \
           -p:InformationalVersion=${{ steps.version.outputs.informationalVersion }} \
           -p:ContinuousIntegrationBuild=true \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: 🚀 Release
 
 on:
   pull_request:
-    branches: [ master, stable ]
+    branches: [ master, stable, dev, 'release/**' ]
     types: [ closed ]
   workflow_dispatch:
     inputs:
@@ -43,11 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.event.pull_request.merged == true && 
-       (contains(github.event.pull_request.base.ref, 'master') || contains(github.event.pull_request.base.ref, 'stable'))) ||
+       (contains(github.event.pull_request.base.ref, 'master') || 
+        contains(github.event.pull_request.base.ref, 'stable') || 
+        contains(github.event.pull_request.base.ref, 'dev') || 
+        startsWith(github.event.pull_request.base.ref, 'release/'))) ||
       (github.event_name == 'workflow_dispatch' && 
        (github.event.inputs.force_release == 'true' || 
         contains(github.ref_name, 'master') || 
-        contains(github.ref_name, 'stable')))
+        contains(github.ref_name, 'stable') || 
+        contains(github.ref_name, 'dev') || 
+        startsWith(github.ref_name, 'release/')))
     
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
@@ -152,7 +157,7 @@ jobs:
         # Branch protection validation
         IS_PROTECTED_BRANCH="false"
         
-        if [[ "$CURRENT_BRANCH" == "master" || "$CURRENT_BRANCH" == "stable" ]]; then
+        if [[ "$CURRENT_BRANCH" == "master" || "$CURRENT_BRANCH" == "stable" || "$CURRENT_BRANCH" == "dev" || "$CURRENT_BRANCH" == release/* ]]; then
           IS_PROTECTED_BRANCH="true"
           echo "✅ Release from protected branch: $CURRENT_BRANCH"
         elif [[ "$FORCE_RELEASE" == "true" ]]; then
@@ -161,7 +166,7 @@ jobs:
           echo "branch_protection_bypassed=true" >> $GITHUB_OUTPUT
         elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
           echo "❌ Manual release from non-protected branch '$CURRENT_BRANCH' requires force_release=true"
-          echo "💡 Protected branches: master, stable"
+          echo "💡 Protected branches: master, stable, dev, release/*"
           echo "should_release=false" >> $GITHUB_OUTPUT
           echo "::error::Cannot create release from '$CURRENT_BRANCH'. Use force_release=true to bypass branch protection, or release from master/stable branches."
           exit 0


### PR DESCRIPTION
This pull request updates the release workflow to support releases from additional branches, improves versioning logic, and clarifies publishing and branch protection rules. The changes ensure more flexible and accurate release management, especially for pre-release and development branches.

**Branch and release workflow enhancements:**

* Expanded the release workflow triggers and branch protection to include `dev` and any `release/*` branches, in addition to `master` and `stable`, allowing releases to be created from these branches as well. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R5) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L46-R55) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L155-R166) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L164-R175)

**Versioning improvements:**

* Updated the logic for setting the `assemblySemFileVer` output to always use a 4-part version number (`major.minor.patch.0`), improving compatibility with .NET assembly versioning requirements. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L119-R130) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L372-R393)
* Adjusted the build step to use the correct versioning variables, ensuring that the assembly and file versions are set according to the new logic.

**Release and publishing logic:**

* Improved logic for determining when to create a release and clarified publishing destinations: stable, beta, and RC releases go to both NuGet.org and GitHub Packages, while other pre-releases (e.g., alpha, development) are published only to GitHub Packages.